### PR TITLE
Année 2018 et lien Meetup édition 2018

### DIFF
--- a/geek-camp/index.html
+++ b/geek-camp/index.html
@@ -5,7 +5,7 @@ title: Geek Camp 2018 - Evénements Okiwi
 <div class="row">
     <div class="col-lg-12">
         <div class="page-header">
-            <h1>Geek Camp 2017</h1>
+            <h1>Geek Camp 2018</h1>
             <h2>14, 15 et 16 septembre à Ruffiac 47700</h2>
         </div>
         <div class="panel panel-default">
@@ -20,7 +20,7 @@ title: Geek Camp 2018 - Evénements Okiwi
                     <li>dormir à la belle étoile</li>
                 </ul>
                 <div class="well">
-                    <a href="https://www.meetup.com/software-craftsmanship-bdx/events/238953527/">Les inscriptions sont ouvertes</a>
+                    <a href="https://www.meetup.com/fr-FR/software-craftsmanship-bdx/events/252589669/">Les inscriptions sont ouvertes</a>
                 </div>
                 <div>
                     <a href="/img/Affiche-GeekCamp2017.png">


### PR DESCRIPTION
Le titre de la page était bien sur 2018, mais pas le contenu ni le lien vers meetup.