### PR TITLE
Création d'un "À propos"

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -44,16 +44,6 @@
                     </a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-item nav-link " href="{{ "/statuts/" | prepend: site.url }}">
-                    Statuts
-                    </a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-item nav-link" href="{{ "/conseil-d-administration/" | prepend: site.url }}">
-                    Conseil d'Administration
-                    </a>
-                </li>
-                <li class="nav-item">
                     <a class="nav-item nav-link " href="{{ "/CoC.html" | prepend: site.url }}">
                     Code de Conduite
                     </a>
@@ -79,6 +69,19 @@
                         Twitter
                     </a>
                   </div>
+                </li>
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                        À propos
+                    </a>
+                    <div class="dropdown-menu">
+                        <a class="dropdown-item" href="{{ "/conseil-d-administration/" | prepend: site.url }}">
+                            Conseil d'Administration
+                        </a>
+                        <a class="dropdown-item" href="{{ "/statuts/" | prepend: site.url }}">
+                            Statuts
+                        </a>
+                    </div>
                 </li>
               </ul>
             </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -49,6 +49,11 @@
                     </a>
                 </li>
                 <li class="nav-item">
+                    <a class="nav-item nav-link" href="{{ "/conseil-d-administration/" | prepend: site.url }}">
+                    Conseil d'Administration
+                    </a>
+                </li>
+                <li class="nav-item">
                     <a class="nav-item nav-link " href="{{ "/CoC.html" | prepend: site.url }}">
                     Code de Conduite
                     </a>

--- a/_layouts/apropos.html
+++ b/_layouts/apropos.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 ---
+
 <div class="container">
     <div class="row">
         <div class="col-xs-12 p-y-3">

--- a/conseil-d-administration/index.md
+++ b/conseil-d-administration/index.md
@@ -1,0 +1,14 @@
+---
+layout: apropos
+---
+
+# Les membres du Conseil d'Administration
+
+- **Président** : Sam Cranford
+- **Vice-Président** : Alain Delachaux
+- **Secrétaire** : Xavier Maso
+- **Trésorière** : Stéfanie Loiseleur
+- Josselin Auguste
+- Jean-Baptiste Dusseault
+- Ludwig Vantours
+- Mikaël Letang

--- a/statuts/index.md
+++ b/statuts/index.md
@@ -2,13 +2,6 @@
 layout: apropos
 ---
 
-# Les membres du bureau
-
-- **Président** : Sam Cranford
-- **Vice-Président** : Alain Delachaux
-- **Secrétaire** : Xavier Maso
-- **Trésorière** : Stéfanie Loiseleur
-
 # Les statuts de l'association
 
 ## Article I - Dénomination

--- a/statuts/index.md
+++ b/statuts/index.md
@@ -1,5 +1,5 @@
 ---
-layout: statuts
+layout: apropos
 ---
 
 # Les membres du bureau


### PR DESCRIPTION
Les objectifs étaient de :
* identifier tout le CA sur le site (ils sont nommés dans les comptes-rendus d'AG, ça rend juste l'information plus accessible)
* séparer les informations du bureau/CA de la page dédiée aux statuts

Ça m'a amené à mettre à jour le menu du site

![2025-05-11T09:12:52,950994828+02:00](https://github.com/user-attachments/assets/883d7490-0d68-4f2e-955c-ec829d59577d)
