### PR TITLE
Correction du lien de code de conduite

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -34,7 +34,7 @@
             <a title="Repositories Github d'Okiwi" href="https://github.com/okiwi">code</a>
             produit par Okiwi sont sous licence <a href="http://www.wtfpl.net/txt/copying/">WTFPL</a>
         </p>
-        <p>Nous tou.te.s adhérons à ce <a href="reglement-interieur.html#article-2--code-de-conduite-de-la-communaut">code de conduite</a></p>
+        <p>Nous tou.te.s adhérons à ce <a href="/reglement-interieur.html#article-2--code-de-conduite-de-la-communaut">code de conduite</a></p>
         <p>Image du clavier de Luis Paniagua sur flickr</p>
     </div>
 </footer>


### PR DESCRIPTION
Sur cette page https://okiwi.org/geek-camp/ le lien vers le code de conduite mène vers cette page https://okiwi.org/geek-camp/reglement-interieur.html#article-2--code-de-conduite-de-la-communaut qui n'existe pas

Je n'ai pas vérifié les autres liens