### PR TITLE
Mise à jour du geek camp de printemps 2026

### DIFF
--- a/geek-camp/index.html
+++ b/geek-camp/index.html
@@ -1,26 +1,25 @@
 ---
 layout: default
-title: Geek Camp 2025 - Évènements Okiwi
+title: Geek Camp 2026 - Évènements Okiwi
 ---
 <div class="container">
     <div class="card" style="border: none"> 
         <div class="card-body">
-            <h2 class="card-title">Les dates pour 2025 sont établies</h2>
+            <h2 class="card-title">Les dates pour 2026</h2>
                 <p class="pt-2">
-                    <h1>Geek Camp de printemps 2025</h1>
-                    <h2>du 27 au 29 juin à Ruffiac (47700)</h2>
+                    <h1>Geek Camp de printemps 2026</h1>
+                    <h2>du vendredi 26 au dimanche 28 juin à Ruffiac (47700)</h2>
                 </p>
                 <p class="row pt-2">
-                    <a href="https://www.meetup.com/software-craftsmanship-bdx/events/307102391/" target="_blank">Les
+                    <a href="https://mobilizon.fr/events/6090cd9f-8178-4103-b94b-5fb73d5edf3f" target="_blank">Les
                         inscriptions sont ouvertes</a>
                 </p>
                 <p class="pt-2">
-                    <h1>Geek Camp d'automne 2025</h1>
-                    <h2>26, 27, et 28 séptembre à Ruffiac (47700)</h2>
+                    <h1>Geek Camp d'automne 2026</h1>
+                    <h2>un week-end fin septembre à Ruffiac (47700)</h2>
                 </p>
                 <p class="row pt-2">
-                    <a href="https://www.meetup.com/software-craftsmanship-bdx/events/307821882/" target="_blank">Les
-                        inscriptions sont ouvertes</a>
+                    Les inscriptions ne sont pas encore ouvertes
                 </p>
             <h3>Un weekend entre aficionados de l'informatique, à la campagne</h3>
             <p>Au programme&nbsp;:</p>


### PR DESCRIPTION
J'ai mis à jour les dates et le lien d'inscription pour le geek camp de printemps 2026.

comme on n'a pas encore de date ou de lien d'inscription pour le geek camp d'automne, j'ai juste corrigé une faute d'orthographe (septembre) et mis à jour la page pour préciser que toutes les dates n'étaient pas encore connues.