### PR TITLE
Ajout des dates du geek camp d'automne 2026

### DIFF
--- a/geek-camp/index.html
+++ b/geek-camp/index.html
@@ -5,7 +5,7 @@ title: Geek Camp 2026 - Évènements Okiwi
 <div class="container">
     <div class="card" style="border: none"> 
         <div class="card-body">
-            <h2 class="card-title">Les dates pour 2026</h2>
+            <h2 class="card-title">Les dates pour 2026 sont établies</h2>
                 <p class="pt-2">
                     <h1>Geek Camp de printemps 2026</h1>
                     <h2>du vendredi 26 au dimanche 28 juin à Ruffiac (47700)</h2>
@@ -16,7 +16,7 @@ title: Geek Camp 2026 - Évènements Okiwi
                 </p>
                 <p class="pt-2">
                     <h1>Geek Camp d'automne 2026</h1>
-                    <h2>un week-end fin septembre à Ruffiac (47700)</h2>
+                    <h2>du vendredi 25 au dimanche 27 septembre à Ruffiac (47700)</h2>
                 </p>
                 <p class="row pt-2">
                     Les inscriptions ne sont pas encore ouvertes


### PR DESCRIPTION
Manu m'a remonté que les dates du geek camp d’automne étaient en fait [connues](https://okiwi-fr.slack.com/archives/C687EJFM0/p1774287738436489?thread_ts=1774252227.819339&cid=C687EJFM0).